### PR TITLE
Allow binding file to be set as a task parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,38 @@ wsdl2java {
 }
 ```
 
+You can optionally specify WSDL and generated source directories like this:
+
+```groovy
+wsdl2java {
+    generatedSourceDir = file("${projectDir}/src/main/service")
+    wsdlDir = file("${projectDir}/src/main/resources")
+}
+```
+
+If your WSDL files breach the `theEnumMemberSizeCap` limit, you can specify a
+JAXB binding file to raise the `theEnumMemberSizeCap` limit like this:
+
+```groovy
+wsdl2java {
+    bindingFile = "${projectDir}/src/main/resources/binding.xjb"
+}
+```
+
+And add a `src/main/resources/binding.xjb` file, e.g.
+
+```xml
+<jxb:bindings xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:jxb="http://java.sun.com/xml/ns/jaxb" version="2.1">
+
+    <!-- Raise theEnumMemberSizeCap limit -->
+    <jxb:bindings>
+        <jxb:globalBindings typesafeEnumMaxMembers="2000" />
+    </jxb:bindings>
+
+</jxb:bindings>
+```
+
 If your WSDL files include non-ANSI characters, you should set the corresponding file encoding in your gradle.properties file. E.g.:
 
 ```properties

--- a/src/main/kotlin/com/github/bjornvester/wsdl2java/Wsdl2JavaPluginExtension.kt
+++ b/src/main/kotlin/com/github/bjornvester/wsdl2java/Wsdl2JavaPluginExtension.kt
@@ -9,6 +9,7 @@ import javax.inject.Inject
 open class Wsdl2JavaPluginExtension @Inject constructor(project: Project) {
     val wsdlDir: DirectoryProperty = project.objects.directoryProperty().convention(project.layout.projectDirectory.dir("src/main/resources"))
     val wsdlFiles: ConfigurableFileCollection = project.objects.fileCollection()
+    val bindingFile: Property<String> = project.objects.property(String::class.java).convention("")
     val generatedSourceDir: DirectoryProperty = project.objects.directoryProperty().convention(project.layout.buildDirectory.dir("generated/wsdl2java"))
     val cxfVersion: Property<String> = project.objects.property(String::class.java).convention("3.3.2")
 }


### PR DESCRIPTION
Allow a single `bindingFile` to be configured for the `wsdl2java` task.

You can now optionally specify a JAXWS or JAXB binding file or XMLBeans context file like this:

```groovy
wsdl2java {
    bindingFile = "${projectDir}/src/main/resources/binding.xjb"
}
```

This adds a single `-b binding-name` parameter to the args passed to `wsdlToJavaClass` constructor.

I need to do this to raise `theEnumMemberSizeCap` limit, see README for details.