### PR TITLE
#8 Support multiple binding files

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Here is a list of all available properties:
 | includes                   | ListProperty\<String> | \["**/*.wsdl"]                                   | Inclusion filers (Ant style) for which WSDLs to include.                                                                                                                                                                                 |
 | includesWithOptions        | Map\<String, List>    | \[not set\]                                      | Inclusion filters like above, but with individual options. See below.                                                                                                                                                                    |
 | generatedSourceDir         | DirectoryProperty     | "$buildDir/generated<br>/sources/wsdl2java/java" | The output directory for the generated Java sources.<br>Note that it will be deleted when running XJC.                                                                                                                                   |
-| bindingFile                | RegularFileProperty   | \[not set\]                                      | A binding file to use in the schema compiler.                                                                                                                                                                                            |
+| bindingFiles               | FileCollection        | \[empty\]                                        | Binding files to use in the schema compiler.                                                                                                                                                                                            |
 | useJakarta                 | Provider\<Boolean>    | true                                             | Set to use the `jakarta` namespace. If false, uses the `javax` namespace. This value also determines the default version of CXF.                                                                                                         |
 | cxfVersion                 | Provider\<String>     | "4.0.2" for jakarta / 3.5.6 for javax            | The version of CXF to use. Use a version >= 4 for `jakarta` and below for `javax`.                                                                                                                                                       |
 | verbose                    | Provider\<Boolean>    | \[not set\]                                      | Enables verbose output from CXF. If not set, it will be be enabled only on the info logging level.                                                                                                                                       |
@@ -168,11 +168,12 @@ Note that the directory will be wiped completely on each run, so don't put other
 
 ### Configure binding files
 
-A binding file can be added like this:
+A binding file can be added like this, multiple binding files are supported:
 
 ```kotlin
 wsdl2java {
-    bindingFile.set(layout.projectDirectory.file("src/main/bindings/binding.xjb"))
+    bindingFile("src/main/bindings/binding.xjb")
+    bindingFile("src/main/bindings/another-binding.xjb")
 }
 ```
 
@@ -202,7 +203,7 @@ dependencies {
 }
 
 wsdl2java {
-    bindingFile.set(layout.projectDirectory.file("src/main/bindings/bindings.xjb"))
+    bindingFile("src/main/bindings/bindings.xjb")
 }
 ```
 

--- a/integration-test/cxf3/bindings-datetime-test/build.gradle.kts
+++ b/integration-test/cxf3/bindings-datetime-test/build.gradle.kts
@@ -8,6 +8,6 @@ dependencies {
 }
 
 wsdl2java {
-    bindingFile.set(layout.projectDirectory.file("src/main/bindings/bindings.xml"))
     useJakarta.set(false)
+    bindingFile("src/main/bindings/bindings.xml")
 }

--- a/integration-test/cxf4/bindings-datetime-test-jakarta/build.gradle.kts
+++ b/integration-test/cxf4/bindings-datetime-test-jakarta/build.gradle.kts
@@ -8,5 +8,5 @@ dependencies {
 }
 
 wsdl2java {
-    bindingFile.set(layout.projectDirectory.file("src/main/bindings/bindings.xml"))
+    bindingFile("src/main/bindings/bindings.xml")
 }

--- a/src/main/kotlin/com/github/bjornvester/wsdl2java/Wsdl2JavaPlugin.kt
+++ b/src/main/kotlin/com/github/bjornvester/wsdl2java/Wsdl2JavaPlugin.kt
@@ -73,7 +73,7 @@ class Wsdl2JavaPlugin : Plugin<Project> {
             wsdlInputDir.convention(group.wsdlDir)
             includes.convention(group.includes)
             includesWithOptions.convention(group.includesWithOptions)
-            bindingFile.convention(group.bindingFile)
+            bindingFiles.from(group.bindingFiles)
             options.convention(group.options)
             verbose.convention(group.verbose)
             suppressGeneratedDate.convention(group.suppressGeneratedDate)

--- a/src/main/kotlin/com/github/bjornvester/wsdl2java/Wsdl2JavaPluginExtension.kt
+++ b/src/main/kotlin/com/github/bjornvester/wsdl2java/Wsdl2JavaPluginExtension.kt
@@ -15,7 +15,7 @@ open class Wsdl2JavaPluginExtension @Inject constructor(objects: ObjectFactory, 
     override val wsdlDir = objects.directoryProperty().convention(layout.projectDirectory.dir("src/main/resources"))
     override val includes = objects.listProperty(String::class.java).convention(listOf("**/*.wsdl"))
     override val includesWithOptions = objects.mapProperty(String::class.java, List::class.java)
-    override val bindingFile = objects.fileProperty()
+    override val bindingFiles = objects.fileCollection()
     override val generatedSourceDir = objects.directoryProperty().convention(layout.buildDirectory.dir("generated/sources/wsdl2java/java"))
     override val options = objects.listProperty(String::class.java)
     override val verbose = objects.property(Boolean::class.java)
@@ -31,7 +31,7 @@ open class Wsdl2JavaPluginExtension @Inject constructor(objects: ObjectFactory, 
             wsdlDir.convention(this@Wsdl2JavaPluginExtension.wsdlDir)
             includes.convention(this@Wsdl2JavaPluginExtension.includes)
             includesWithOptions.convention(this@Wsdl2JavaPluginExtension.includesWithOptions)
-            bindingFile.convention(this@Wsdl2JavaPluginExtension.bindingFile)
+            bindingFiles.from(this@Wsdl2JavaPluginExtension.bindingFiles)
             generatedSourceDir.convention(layout.buildDirectory.dir("generated/sources/wsdl2java-$name/java"))
             options.convention(this@Wsdl2JavaPluginExtension.options)
             verbose.convention(this@Wsdl2JavaPluginExtension.verbose)
@@ -54,5 +54,15 @@ open class Wsdl2JavaPluginExtension @Inject constructor(objects: ObjectFactory, 
 
         @JvmStatic
         val GENERATED_STYLE_JAKARTA = "jakarta"
+    }
+
+    /**
+     * Adds a binding file. The given path is evaluated as per [org.gradle.api.Project.file].
+     *
+     * @param path The binding file to add.
+     * @return this
+     */
+    fun bindingFile(path: Any) {
+        bindingFiles.from(path)
     }
 }

--- a/src/main/kotlin/com/github/bjornvester/wsdl2java/Wsdl2JavaPluginExtensionGroup.kt
+++ b/src/main/kotlin/com/github/bjornvester/wsdl2java/Wsdl2JavaPluginExtensionGroup.kt
@@ -1,7 +1,7 @@
 package com.github.bjornvester.wsdl2java
 
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
@@ -11,7 +11,7 @@ interface Wsdl2JavaPluginExtensionGroup {
     val wsdlDir: DirectoryProperty
     val includes: ListProperty<String>
     val includesWithOptions: MapProperty<String, List<*>>
-    val bindingFile: RegularFileProperty
+    val bindingFiles: ConfigurableFileCollection
     val generatedSourceDir: DirectoryProperty
     val options: ListProperty<String>
     val verbose: Property<Boolean>

--- a/src/main/kotlin/com/github/bjornvester/wsdl2java/Wsdl2JavaTask.kt
+++ b/src/main/kotlin/com/github/bjornvester/wsdl2java/Wsdl2JavaTask.kt
@@ -34,10 +34,9 @@ abstract class Wsdl2JavaTask @Inject constructor(
     @get:Input
     val includesWithOptions = objects.mapProperty(String::class.java, List::class.java).convention(getWsdl2JavaExtension().includesWithOptions)
 
-    @get:InputFile
+    @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
-    @Optional
-    val bindingFile = objects.fileProperty().convention(getWsdl2JavaExtension().bindingFile)
+    val bindingFiles = objects.fileCollection().from(getWsdl2JavaExtension().bindingFiles)
 
     @get:Input
     @Optional
@@ -193,11 +192,11 @@ abstract class Wsdl2JavaTask @Inject constructor(
             defaultArgs.add("-verbose")
         }
 
-        if (bindingFile.isPresent) {
+        bindingFiles.forEach {
             defaultArgs.addAll(
                 listOf(
                     "-b",
-                    bindingFile.get().asFile.absolutePath
+                    it.absolutePath
                 )
             )
         }


### PR DESCRIPTION
I've switched to `FileCollection` for the extension/task property and added a convenience method to the extension so users won't necessarily have to deal with the `FileCollection.from()` syntax.

This appeared to me as the most "natural" approach, opposed to having a `ListProperty<File>` (inconsistent with the other properties) oder even `ListProperty<RegularFile>` (a bit painful to handle, `layout.file()` syntax being not commonly known/understood by users).

~~ One thing where I wasn't 100% sure was how to configure the `FileCollection` task property from the extension property. Here the convention approach is not available and there aren't any super clear docs/examples how to do this. But it seems to work alright the way it's done here. ~~

Edit: after being a bit more versed in the approach to lazy configuration of gradle tasks, I'd argue that the approach taken in the plugin is not 100% idiomatic. Typically one would not refer to the extension properties in the task implementation.
Rather there the task properties should be "unbiased" and preferable empty, except obvious defaults.
The plugin implementation should instead be responsible of connecting the extension properties to the task properties.

However, in this PR I've gone along with the approach taken here.

