### PR TITLE
Fix visibility of generated sources directory to Kotlin compilation

### DIFF
--- a/src/main/kotlin/com/github/bjornvester/wsdl2java/Wsdl2JavaPlugin.kt
+++ b/src/main/kotlin/com/github/bjornvester/wsdl2java/Wsdl2JavaPlugin.kt
@@ -4,8 +4,10 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.tasks.SourceSet.MAIN_SOURCE_SET_NAME
 import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.kotlin.dsl.withConvention
 import org.gradle.util.GradleVersion
 
 class Wsdl2JavaPlugin : Plugin<Project> {
@@ -39,11 +41,11 @@ class Wsdl2JavaPlugin : Plugin<Project> {
             dependencies.add(project.dependencies.create("jakarta.jws:jakarta.jws-api:1.1.1"))
         }
 
-        project.tasks.register(WSDL2JAVA_TASK_NAME, Wsdl2JavaTask::class.java) {
-            val sourceSets = project.properties["sourceSets"] as SourceSetContainer
+        val task = project.tasks.register(WSDL2JAVA_TASK_NAME, Wsdl2JavaTask::class.java)
 
+        project.withConvention(JavaPluginConvention::class) {
             sourceSets.named(MAIN_SOURCE_SET_NAME) {
-                java.srcDir(sourcesOutputDir)
+                java.srcDir(task.map { it.sourcesOutputDir })
             }
         }
 


### PR DESCRIPTION
You've created a nice plugin, thank you for your efforts.
I've been trying to use the generated Java sources from Kotlin. The Kotlin compiler did not see the generated sources directory and threw a lot of compilation errors at me. That's when I discovered that the logic of registering the generated sources directory is inside-out:

* **Previously**, adding the directory was located inside the lazy configuration of `Wsdl2JavaTask`. To my insight, if Gradle did not configure the task, the plugin did not add the generated sources as `srcDir`.
* **Now** adding the generated sources as source directory happens in all cases independent of running the task's configuration closure. The set of source directories will always contain the property `sourcesOutputDir` of the plugin.

The new way also causes the Kotlin compiler to recognize the generated sources directory as input and I compiled happily thereafter.
I'd be glad if you could integrate the patch and drop a new release.

