### PR TITLE
Added possibility of specifying namespace-specific package names

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,15 @@ wsdl2java {
 }
 
 ```
+You can also specify a comma separated list of namespace-specific package names:
+```kotlin
+wsdl2java {
+    packageName.set("http://first.namespace=com.github.bjornvester.wsdl2java.namespace.first,"+
+                    "http://second.namespace=com.github.bjornvester.wsdl2java.namespace.second")
+}
+
+```
+
 
 ### Configure encoding
 

--- a/src/main/kotlin/com/github/bjornvester/wsdl2java/Wsdl2JavaTask.kt
+++ b/src/main/kotlin/com/github/bjornvester/wsdl2java/Wsdl2JavaTask.kt
@@ -194,7 +194,11 @@ abstract class Wsdl2JavaTask @Inject constructor(
         }
 
         if (packageName.isPresent && packageName.get().isNotBlank()) {
-            defaultArgs.addAll(listOf("-p", packageName.get()))
+            //interpret packageName as a comma separated list of package name declarations. This won't break
+            //existing configurations that only have one package name
+            packageName.get().split(",").forEach{ p->
+                defaultArgs.addAll(listOf("-p", p))
+            }
         }
 
         // Add the verbose parameter if explicitly configured to true, or if not set but info logging is enabled


### PR DESCRIPTION
This fixes issue #17 by allowing a comma-separated list to be passed to the packageName property. This way, older configurations only containing a simple package name will continue to work as before. 